### PR TITLE
Initialise Checker on startup

### DIFF
--- a/src/checker-loop.js
+++ b/src/checker-loop.js
@@ -28,7 +28,8 @@ async function runCheck(params, messageSender, messageFormatter) {
     }, refreshServicesInterval * 1000);
   }
 
-  const checker = new Checker(secondsUntilAlert);
+  const initialServiceStates = await ecsApi.runCheckInBatches(ecsCluster, serviceNameBatches);
+  const checker = new Checker(secondsUntilAlert, initialServiceStates);
   const intervalLogger = utils.runInInterval(logInterval, utils.printLogContent);
 
   setInterval(async () => {

--- a/src/ecs-api.js
+++ b/src/ecs-api.js
@@ -76,6 +76,7 @@ ${JSON.stringify(apiResponse.failures)}`);
     deploymentCreated: primaryDeployment.updatedAt,
     taskDef: primaryDeployment.taskDefinition,
     runningCount: totalRunning,
+    deploymentRunningCount: primaryDeployment.runningCount,
     desiredCount: primaryDeployment.desiredCount,
   };
 }

--- a/src/templates/default-message-templates.js
+++ b/src/templates/default-message-templates.js
@@ -4,7 +4,7 @@ module.exports = {
   deploy: serviceState => `:arrows_clockwise: \`${serviceState.service}\` deployment started with task definition \`${serviceState.taskDef}\``,
   scale: serviceState => `:arrow_up_down: \`${serviceState.service}\` scaling event started - scaling to \`${serviceState.desiredCount}\` instances. Currently: \`${serviceState.runningCount}\``,
   recover: serviceState => `:warning: \`${serviceState.service}\` task crashed! \`${serviceState.runningCount}\` running tasks (desired: \`${serviceState.desiredCount}\`). This is usually an error! Please check the logs`,
-  deployDone: serviceState => `:white_check_mark: \`${serviceState.service}\` deployment done with \`${serviceState.runningCount}\` instances and task definition \`${serviceState.taskDef}\``,
+  deployDone: serviceState => `:white_check_mark: \`${serviceState.service}\` deployment done with \`${serviceState.deploymentRunningCount}\` instances and task definition \`${serviceState.taskDef}\``,
   deployTimeout: serviceState => `:thinking_face: \`${serviceState.service}\` deployment is taking a very long time`,
   monitorDeploy: (serviceNames, cluster) => `:white_check_mark: \`Mona\` is deployed and monitoring ECS cluster \`${cluster}\``
 };

--- a/tests/checker-alert-creation.test.js
+++ b/tests/checker-alert-creation.test.js
@@ -88,6 +88,24 @@ describe('Deployment checker', () => {
       checkAlerts(result2, { serviceDeployTimeoutAlerts: 1 });
     });
 
+    test('When scaling is running for a long time, should alert', () => {
+      const apiResults = [
+        {
+          a: mockResults('a', { desiredCount: 2 }),
+          b: mockResults('b'),
+        },
+        {
+          a: mockResults('a', { desiredCount: 2, deploymentCreated: moment().subtract(1, 'h') }),
+          b: mockResults('b'),
+        },
+      ];
+      const result1 = checker.iterate(apiResults[0]);
+      checkAlerts(result1, { serviceScalingAlerts: 1 });
+
+      const result2 = checker.iterate(apiResults[1]);
+      checkAlerts(result2, { serviceDeployTimeoutAlerts: 1 });
+    });
+
     test('When deployment is running again for same ver, should alert', () => {
       const apiResults = [
         {

--- a/tests/checker-status-calculations.test.js
+++ b/tests/checker-status-calculations.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const { DEPLOYMENT_STATES } = require('../src/consts');
+const { mockResults } = require('./test-utils');
+const Checker = require('../src/Checker');
+
+describe('Deployment checker', () => {
+  let checker;
+
+  beforeEach(() => {
+    const initialApiResults = {
+      a: mockResults('a'),
+      b: mockResults('b'),
+    };
+    checker = new Checker(10, initialApiResults);
+  });
+
+  describe('Calculate deployment status', () => {
+    test('When deployment is stable, state is STABLE', () => {
+      const apiResults = {
+        a: mockResults('a'),
+        b: mockResults('b'),
+      };
+
+      const result = checker.iterate(apiResults);
+      expect(result.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.STABLE);
+      expect(result.serviceDeployStates.b).toEqual(DEPLOYMENT_STATES.STABLE);
+    });
+
+    test('When deployment is not stable, state is DEPLOYING', () => {
+      const apiResults = {
+        a: mockResults('a', { deploymentId: 'deployment2', deploymentRunningCount: 0 }),
+        b: mockResults('b'),
+      };
+
+      const result = checker.iterate(apiResults);
+      expect(result.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.DEPLOYING);
+      expect(result.serviceDeployStates.b).toEqual(DEPLOYMENT_STATES.STABLE);
+    });
+
+    test('When deployment is not stable, but deploymentId didn\'t change, state is RECOVER', () => {
+      const result1 = checker.iterate({ a: mockResults('a') });
+      expect(result1.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.STABLE);
+
+      const result2 = checker.iterate({ a: mockResults('a', { deploymentRunningCount: 0 }) });
+      expect(result2.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.RECOVER);
+    });
+
+    test('When deployment is not stable, and desiredCount changed, state is SCALING', () => {
+      const result1 = checker.iterate({ a: mockResults('a') });
+      expect(result1.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.STABLE);
+
+      const result2 = checker.iterate({ a: mockResults('a', { desiredCount: 2 }) });
+      expect(result2.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.SCALING);
+    });
+
+    test('When both deployment changed and desiredCount changed, state is DEPLOYING', () => {
+      const result = checker.iterate({ a: mockResults('a', { deploymentId: 'a', desiredCount: 2 }) });
+      expect(result.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.DEPLOYING);
+    });
+
+    test('If a task crashed while another deployment was active, state is still RECOVER', () => {
+      const result = checker.iterate({ a: mockResults('a', { deploymentRunningCount: 0 }) });
+      expect(result.serviceDeployStates.a).toEqual(DEPLOYMENT_STATES.RECOVER);
+    });
+  });
+});

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const moment = require('moment');
+
+function mockResults(service, overrides = {}) {
+  return {
+    service,
+    deploymentId: overrides.deploymentId || 'deploymentId',
+    deploymentCreated: overrides.deploymentCreated || moment(),
+    desiredCount: ('desiredCount' in overrides) ? overrides.desiredCount : 1,
+    runningCount: ('runningCount' in overrides) ? overrides.runningCount : 1,
+    deploymentRunningCount: ('deploymentRunningCount' in overrides) ? overrides.deploymentRunningCount : 1,
+    taskDef: overrides.taskDef || 'taskDef',
+  };
+}
+
+function checkAlerts(result, expected) {
+  expect(_createResultObject(result)).toEqual(_createExpectedObject(expected));
+}
+
+function _createResultObject(result) {
+  return {
+    serviceDeployingAlerts: result.serviceDeployingAlerts.length,
+    serviceDeployDoneAlerts: result.serviceDeployDoneAlerts.length,
+    serviceDeployTimeoutAlerts: result.serviceDeployTimeoutAlerts.length,
+    serviceScalingAlerts: result.serviceScalingAlerts.length,
+    serviceRecoverAlerts: result.serviceRecoverAlerts.length,
+  }
+}
+
+function _createExpectedObject(expected) {
+  return {
+    serviceDeployingAlerts: ('serviceDeployingAlerts' in expected) ? expected.serviceDeployingAlerts : 0,
+    serviceDeployDoneAlerts: ('serviceDeployDoneAlerts' in expected) ? expected.serviceDeployDoneAlerts : 0,
+    serviceDeployTimeoutAlerts: ('serviceDeployTimeoutAlerts' in expected) ? expected.serviceDeployTimeoutAlerts : 0,
+    serviceScalingAlerts: ('serviceScalingAlerts' in expected) ? expected.serviceScalingAlerts : 0,
+    serviceRecoverAlerts: ('serviceRecoverAlerts' in expected) ? expected.serviceRecoverAlerts : 0,
+  }
+}
+
+module.exports = {
+  mockResults,
+  checkAlerts,
+};


### PR DESCRIPTION
This prevents mistaking new deployments for crashes